### PR TITLE
Added more service provider with country in the provider.js file

### DIFF
--- a/tracker/src/provider.js
+++ b/tracker/src/provider.js
@@ -2,27 +2,54 @@
 
 // Sample service provider data (for demonstration purposes)
 const serviceProviders = {
-    '+1': 'AT&T',
-    '+44': 'Vodafone UK',
-    '+91': 'Airtel',
-    '+33': 'Orange France',
-    '+49': 'Telekom Deutschland',
-    '+61': 'Telstra Australia',
-    '+81': 'NTT DOCOMO',
-    '+82': 'SK Telecom',
-    '+86': 'China Mobile',
-    '+90': 'Turkcell',
-    '+92': 'Jazz Pakistan',
-    '+234': 'MTN Nigeria',
-    '+254': 'Safaricom Kenya',
-    '+966': 'STC Saudi Arabia',
-    '+971': 'Etisalat UAE',
-    '+92': 'Telenor Pakistan',
-    '+93': 'Roshan Afghanistan',
-    '+355': 'Vodafone Albania',
-    '+375': 'MTS Belarus',
-    '+598': 'Antel Uruguay',
-    // Add more service providers and country codes here
+  "+1": "AT&T",
+  "+44": "Vodafone UK",
+  "+91": "Airtel",
+  "+33": "Orange France",
+  "+49": "Telekom Deutschland",
+  "+61": "Telstra Australia",
+  "+81": "NTT DOCOMO",
+  "+82": "SK Telecom",
+  "+86": "China Mobile",
+  "+90": "Turkcell",
+  "+92": "Jazz Pakistan",
+  "+234": "MTN Nigeria",
+  "+254": "Safaricom Kenya",
+  "+966": "STC Saudi Arabia",
+  "+971": "Etisalat UAE",
+  "+93": "Roshan Afghanistan",
+  "+355": "Vodafone Albania",
+  "+375": "MTS Belarus",
+  "+598": "Antel Uruguay",
+  "+52": "Telcel Mexico",
+  "+55": "Vivo Brazil",
+  "+356": "GO Malta",
+  "+977": "Nepal Telecom",
+  "+81": "SoftBank Japan",
+  "+82": "KT Corporation South Korea",
+  "+852": "HKT Hong Kong",
+  "+886": "Chunghwa Telecom Taiwan",
+  "+94": "Dialog Axiata Sri Lanka",
+  "+880": "Grameenphone Bangladesh",
+  "+93": "Roshan Afghanistan",
+  "+46": "Tele2 Sweden",
+  "+30": "Cosmote Greece",
+  "+7": "MTS Russia",
+  "+65": "Singtel Singapore",
+  "+46": "Telia Sweden",
+  "+34": "Movistar Spain",
+  "+351": "Vodafone Portugal",
+  "+39": "TIM Italy",
+  "+27": "Vodacom South Africa",
+  "+20": "Orange Egypt",
+  "+962": "Zain Jordan",
+  "+503": "Claro El Salvador",
+  "+506": "Kölbi Costa Rica",
+  "+54": "Claro Argentina",
+  "+598": "Movistar Uruguay",
+  "+52": "Movistar Mexico",
+  "+57": "Claro Colombia",
+  // Add more service providers and country codes here
 };
 
 /**
@@ -31,9 +58,9 @@ const serviceProviders = {
  * @returns {string} - The service provider name or 'Unknown Service Provider'.
  */
 function getServiceProvider(countryCode) {
-    return serviceProviders[countryCode] || 'Unknown Service Provider';
+  return serviceProviders[countryCode] || "Unknown Service Provider";
 }
 
 module.exports = {
-    getServiceProvider,
+  getServiceProvider,
 };


### PR DESCRIPTION
There were too less details about the telecom service providers due to that  the user would have not received the countries and the provider's names of many numbers, so I added more service providers which maps country codes with the provider's names and the country's name in which they are providing services.

file modified - src/provider.js 